### PR TITLE
First run config

### DIFF
--- a/ENVS.example
+++ b/ENVS.example
@@ -18,7 +18,7 @@ export OUTPUT_DIR=${OUTPUT_DIR:-${PIPELINE_DIRECTORY}/output}
 export ASLI_VENV=${ASLI_VENV:-${PIPELINE_DIRECTORY}/asli_env/bin/activate}
 
 ## Validation Checks
-export FIRST_RUN=TRUE
+export FIRST_RUN=true
 
 ## File Movement
 # Specify the destination of the files and export method

--- a/ENVS.example
+++ b/ENVS.example
@@ -17,6 +17,9 @@ export OUTPUT_DIR=${OUTPUT_DIR:-${PIPELINE_DIRECTORY}/output}
 # Specify environment so it does not need to be called prior to running
 export ASLI_VENV=${ASLI_VENV:-${PIPELINE_DIRECTORY}/asli_env/bin/activate}
 
+## Validation Checks
+export FIRST_RUN=TRUE
+
 ## File Movement
 # Specify the destination of the files and export method
 # This will also determine file format (ie .nc or .zarr, .csv or .parquet)

--- a/ENVS.example
+++ b/ENVS.example
@@ -18,6 +18,9 @@ export OUTPUT_DIR=${OUTPUT_DIR:-${PIPELINE_DIRECTORY}/output}
 export ASLI_VENV=${ASLI_VENV:-${PIPELINE_DIRECTORY}/asli_env/bin/activate}
 
 ## Validation Checks
+# Whether this is the first run against a file destination
+# Setting this to true will prevent the pipeline from running verification
+# against a file that does not yet exist
 export FIRST_RUN=true
 
 ## File Movement

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ cp ENVS.example ENVS.myconfig
 ln -sf ENVS.myconfig ENVS
 # Edit ENVS.myconfig to customise parameters for the pipeline
 ```
+
+Please inspect this file when running the pipeline for the first time. In particular `$FIRST_RUN` might prevent you from succesfully running the pipeline when set to `false` on first run.
+
 ## Data Output
 The pipeline allows data output to the JASMIN Object Store, a local file system, or both - depending on where you are running this pipeline and which output file formats you would like to use.
 

--- a/run_asli_pipeline.sh
+++ b/run_asli_pipeline.sh
@@ -32,20 +32,24 @@ case ${FILE_DESTINATION} in
 	OBJECT_STORAGE)
 		# Run checks on whether new data matches previous data
 		# Provide old and new file
-		Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
+		if [! $FIRST_RUN]; then
+			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
+		fi
 
 		bash src/04_export_to_object_store.sh
 		;;
 	# Putting in a fallthrough for BOTH
 	# ie when BOTH is matched, it also runs FILE_SYSTEM
 	BOTH)
-		Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
-
+		if [! $FIRST_RUN]; then
+			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
+		fi
 		bash src/04_export_to_object_store.sh
 		;&
 	FILE_SYSTEM)
-		Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$RSYNC_LOCATION/asli_calculation_$FILE_IDENTIFIER.csv"
-
+		if [! $FIRST_RUN]; then
+			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
+		fi
 		bash src/04_export_to_file_system.sh
 		;;
 	*)

--- a/run_asli_pipeline.sh
+++ b/run_asli_pipeline.sh
@@ -32,7 +32,7 @@ case ${FILE_DESTINATION} in
 	OBJECT_STORAGE)
 		# Run checks on whether new data matches previous data
 		# Provide old and new file
-		if [! $FIRST_RUN]; then
+		if [[ "${FIRST_RUN}" != true ]]; then
 			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
 		fi
 
@@ -41,13 +41,13 @@ case ${FILE_DESTINATION} in
 	# Putting in a fallthrough for BOTH
 	# ie when BOTH is matched, it also runs FILE_SYSTEM
 	BOTH)
-		if [! $FIRST_RUN]; then
+		if [[ "${FIRST_RUN}" != true ]]; then
 			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
 		fi
 		bash src/04_export_to_object_store.sh
 		;&
 	FILE_SYSTEM)
-		if [! $FIRST_RUN]; then
+		if [[ "${FIRST_RUN}" != true ]]; then
 			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
 		fi
 		bash src/04_export_to_file_system.sh

--- a/run_asli_pipeline.sh
+++ b/run_asli_pipeline.sh
@@ -32,6 +32,7 @@ case ${FILE_DESTINATION} in
 	OBJECT_STORAGE)
 		# Run checks on whether new data matches previous data
 		# Provide old and new file
+		# Only run if it is not the first run, ie there is a file to compare against
 		if [[ "${FIRST_RUN}" != true ]]; then
 			Rscript src/03_verify_no_past_changes.R "$OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv" "$S3_BUCKET/asli_calculation_$FILE_IDENTIFIER.csv"
 		fi

--- a/src/04_export_to_object_store.sh
+++ b/src/04_export_to_object_store.sh
@@ -11,7 +11,7 @@ total_files=$(echo "$file_list" | wc -l)
 
 counter=0
 for file in $OUTPUT_DIR/*; do
-    ((counter++))
+    ((counter+1))
     percentage=$((counter * 100 / total_files))
 
     echo -ne "Progress: ["


### PR DESCRIPTION
Closes #24 

Adding in "FIRST_RUN" configuration. Can be set to true to prevent running verification checks against a file that does not exist, when running against an export location for the first time