### PR TITLE
separate data download from the rest of the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Before running the pipeline, make sure you have followed the steps above:
 You can now run the pipeline:
 ```bash
 deactivate # Your environment is set in ENVS, so you do not need to call it
+
+# Download the era5 data first
+bash src/00_download_era5.sh
+
+# Then run the whole pipeline
 bash run_asli_pipeline.sh
 ```
 
@@ -94,7 +99,7 @@ A cron example has been provided in the `cron.example` file.
 crontab -e
 
 # Then edit the file, for example to run once a month:
-0 3 1 * * cd $HOME/boost-eds-pipeline && bash run_asli_pipeline.sh; deactivate
+0 3 1 * * cd $HOME/asli-pipeline && bash run_asli_pipeline.sh; deactivate
 
 # OR on JASMIN we are using crontamer:
 0 3 1 * * crontamer -t 2h -e youremail@address.ac.uk 'cd gws/nopw/j04/dit/users/thozwa/asli-pipeline && bash run_asli_pipeline.sh; deactivate'
@@ -107,6 +112,10 @@ If you need to submit this pipeline to SLURM (for example [on JASMIN](https://he
 However, you can include `sbatch` headers when you call the executable script: 
 
 ```bash
+# Downloading era5 data first, due to SLURM timeouts and CDS api response time
+# it is recommended to not send this script as a job to SLURM
+bash src/00_download_era5.sh
+
 # Submitting a job to the short-serial partition on JASMIN
 sbatch -p short-serial -t 03:00 -o job01.out -e job01.err run_asli_pipeline.sh`
 ```
@@ -116,6 +125,13 @@ On the BAS HPC, remember to set the working directory. For example:
 ```bash
 # On the rocky machine, otherwise 'rocky' becomes 'short'
 sbatch -p rocky -A rocky -t 00:30 -D /users/USERNAME/asli-pipeline -o /data/hpcdata/users/USERNAME/out/asli_run.%i.%N.out -e /data/hpcdata/users/USERNAME/out/asli_run.%i.%N.err run_asli_pipeline.sh
+```
+
+## Combining cron and SLURm
+Below is a cron example of the entire pipeline running once a month on the BAS HPC:
+
+```bash
+0 3 1 * * cd $HOME/asli-pipeline && bash src/00_download_era5.sh && sbatch -p rocky -A rocky -t 00:30 -D /users/USERNAME/asli-pipeline -o /data/hpcdata/users/USERNAME/out/asli_run.%i.%N.out -e /data/hpcdata/users/USERNAME/out/asli_run.%i.%N.err run_asli_pipeline.sh; deactivate
 ```
 
 ## Deployment Example

--- a/run_asli_pipeline.sh
+++ b/run_asli_pipeline.sh
@@ -7,17 +7,7 @@ source ENVS
 # Activate virtual environment
 source ${ASLI_VENV}
 
-# Put all relevant directories in a list
-DIR_LIST=($DATA_DIR $OUTPUT_DIR)
-
-# Create them if they do not exist
-for dir in ${DIR_LIST[@]};
-do
-	if [ ! -d $dir ]; then
-  		mkdir -p $dir
-		echo "Created $dir"
-	fi
-done
+# Data should already have been fetched with 00_download_era5.sh
 
 # Run calculations, writes an output file in $OUTPUT_DIR
 bash src/01_run_asli_calculations.sh

--- a/src/00_download_era5.sh
+++ b/src/00_download_era5.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Read in config file
+source ENVS
+
+# Activate virtual environment
+source ${ASLI_VENV}
+
+# Put all relevant directories in a list
+DIR_LIST=($DATA_DIR $OUTPUT_DIR)
+
+# Create them if they do not exist
+for dir in ${DIR_LIST[@]};
+do
+	if [ ! -d $dir ]; then
+  		mkdir -p $dir
+		echo "Created $dir"
+	fi
+done
+
+# Fetch land sea mask, automatically writes in data directory
+# Everything is pre-set in asli functions, no arguments needed for our purpose
+asli_data_lsm
+
+# Downloading latest ERA5 data, provide information to the user
+echo "Requesting with the following arguments: $DATA_ARGS_ERA5".
+asli_data_era5 $DATA_ARGS_ERA5

--- a/src/01_run_asli_calculations.sh
+++ b/src/01_run_asli_calculations.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 set -e
 
-# Fetch land sea mask, automatically writes in data directory
-# Everything is pre-set in asli functions, no arguments needed for our purpose
-asli_data_lsm
-
-# Downloading latest ERA5 data, provide information to the user
-echo "Requesting with the following arguments: $DATA_ARGS_ERA5".
-asli_data_era5 $DATA_ARGS_ERA5
-
 # Run calculation, specifying output location
 # output.csv will need to be renamed to sensible unique identifier 
 asli_calc $DATA_DIR/era5_mean_sea_level_pressure_monthly_*.nc -o $OUTPUT_DIR/asli_calculation_$FILE_IDENTIFIER.csv
-# probably move into sbatch to run on lotus - not strictly required but nice for reproducibility


### PR DESCRIPTION
Due to varying response times of the CDS API, sending the entire pipeline to SLURM can results in a TIMEOUT exit code 0 when the response is > 300 seconds, as the node is idle.

This PR separates the downloading of data from CDS from the rest of the pipeline, so data can be downloaded and the rest of the pipeline (processing, qa) can be sent as a SLURM job. 